### PR TITLE
Adjust test when inserting non-nullable email field

### DIFF
--- a/tests/test_fastapi_users_db_sqlalchemy.py
+++ b/tests/test_fastapi_users_db_sqlalchemy.py
@@ -107,7 +107,10 @@ async def test_queries(sqlalchemy_user_db: SQLAlchemyUserDatabase[UserDB]):
 
     # Exception when inserting non-nullable fields
     with pytest.raises(sqlite3.IntegrityError):
-        wrong_user = UserDB(hashed_password="aaa")
+        # Set an email when the instance is created to pass the Pydantic check
+        wrong_user = UserDB(hashed_password="aaa", email="arthur@camelot.bt")
+        # and removes it for the test
+        wrong_user.email = None  # type: ignore
         await sqlalchemy_user_db.create(wrong_user)
 
     # Unknown user


### PR DESCRIPTION
Without this workaround, the test raises an Pydantic error:

```
tests/test_fastapi_users_db_sqlalchemy.py:110: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   ???
E   pydantic.error_wrappers.ValidationError: 1 validation error for UserDB
E   email
E     value is not a valid email address (type=value_error.email)

pydantic/main.py:406: ValidationError
```

My env uses pydantic==1.8.2 (same version as the CI so I don't know why the behavior is different for me).