### PR TITLE
[RFC] SQLAlchemyUserDatabase with engine injection instead of session injection

### DIFF
--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -30,13 +30,11 @@ async def sqlalchemy_user_db() -> AsyncGenerator[SQLAlchemyUserDatabase, None]:
     engine = create_async_engine(
         DATABASE_URL, connect_args={"check_same_thread": False}
     )
-    sessionmaker = create_async_session_maker(engine)
 
     async with engine.begin() as connection:
         await connection.run_sync(Base.metadata.create_all)
 
-        async with sessionmaker() as session:
-            yield SQLAlchemyUserDatabase(UserDB, session, User)
+        yield SQLAlchemyUserDatabase(UserDB, engine, User)
 
         await connection.run_sync(Base.metadata.drop_all)
 
@@ -57,13 +55,11 @@ async def sqlalchemy_user_db_oauth() -> AsyncGenerator[SQLAlchemyUserDatabase, N
     engine = create_async_engine(
         DATABASE_URL, connect_args={"check_same_thread": False}
     )
-    sessionmaker = create_async_session_maker(engine)
 
     async with engine.begin() as connection:
         await connection.run_sync(Base.metadata.create_all)
 
-        async with sessionmaker() as session:
-            yield SQLAlchemyUserDatabase(UserDBOAuth, session, User, OAuthAccount)
+        yield SQLAlchemyUserDatabase(UserDBOAuth, engine, User, OAuthAccount)
 
         await connection.run_sync(Base.metadata.drop_all)
 


### PR DESCRIPTION
Hi!

Huge fan of fastapi-users.

This library in particular is a huge help to spin up with it quickly, since I prefer to use Postgres + SQLAlchemy backend for my database repository implementations.

However, I find this library hard to use in the standard way I like, which is to perform all dependency injection on startup, instantiating the database engine and injecting it into the repository implementation (whose role is played here by `SQLAlchemyUserDatabase`) only once, in the main file (example [here](https://github.com/francoposa/domain-driven-design-service-examples/blob/main/python/fastapi/entity-service/api/main.py)). The repository instance then uses the engine to instantiate the sessions as needed, encapsulating the repo functionality behind a domain-layer interface which is completely agnostic of DB implementation details - no need for the consumer of the interface to know that it's using SQLAlchemy or any other infrastructure details.

However, the API of the `SQLAlchemyUserDatabase` class in this library only can take a session, meaning the session must be instantiated outside of the class, then the class must be instantiated each time the request handler is called. I have found it very difficult (maybe impossible?) to maintain proper clean/hexagonal/layered architecture this way, as all callers of the repository methods must supply a database session, which is not something business logic code should be concerned with.

Would you be open to introducing something like this into this library? It's not a major change, and I could of course maintain a fork for my own purposes, but I hope it could be better for everyone to include the option in this upstream library that the vast majority of people would use by default.

The changes I have here are of course not compatible with the existing API of `SQLAlchemyUserDatabase`, but are just a proof of concept - I figured I'd wait to go for compatibility after getting your opinion on the matter.

The implementations could be made compatible with the addition of the option to provide `engine` _or_ `session` to the class init, then handling things accordingly within the `session` helper method, like:

```python
def session(self) -> AsyncSession:
    if self._session:  # was provided on class instantiation instead of an engine
        return self._session
    # otherwise the session was not provided on class init, so we create one from the engine
    return sessionmaker(self.engine, class_=AsyncSession)()
```

Alternatively, the version with engine injected could be a completely separate class with this slightly different implementation.