### PR TITLE
Fix Postgres "idle in transaction" when getting current user

### DIFF
--- a/fastapi_users_db_sqlalchemy/__init__.py
+++ b/fastapi_users_db_sqlalchemy/__init__.py
@@ -186,4 +186,5 @@ class SQLAlchemyUserDatabase(Generic[UP, ID], BaseUserDatabase[UP, ID]):
 
     async def _get_user(self, statement: Select) -> Optional[UP]:
         results = await self.session.execute(statement)
+        await self.session.rollback()
         return results.unique().scalar_one_or_none()


### PR DESCRIPTION
When interacting with a Postgres database, particularly during the process of querying user info, I found that the database connection remains persistently open in an `idle in transaction` state. This issue may lead to inefficient resource utilization and potential database locks. So I propose to add explicit rollback command after the query operation. This will change connection state to a standard `idle`

## Steps to reproduce

1) Clone [fastapi-users sqlalchemy examples](https://github.com/fastapi-users/fastapi-users/tree/master/examples/sqlalchemy)
2) Make breakpoint in some auth-only endpoint, for example [in this one](https://github.com/fastapi-users/fastapi-users/blob/master/examples/sqlalchemy/app/app.py#L36)
3) Open Postgres console and query active sessions:
```sql
SELECT state, query FROM pg_stat_activity WHERE client_addr IS NOT NULL;
-- | state                | query                 |
-- | -------------------- | --------------------- |
-- | idle in transaction  | SELECT "user".id, ... | <--- here
-- | active               | SELECT state, ...     |
```

