### PR TITLE
Fix type and use OAP instead of concrete type

### DIFF
--- a/fastapi_users_db_sqlalchemy/__init__.py
+++ b/fastapi_users_db_sqlalchemy/__init__.py
@@ -104,13 +104,13 @@ class SQLAlchemyUserDatabase(Generic[UP, ID], BaseUserDatabase[UP, ID]):
 
     session: AsyncSession
     user_table: Type[UP]
-    oauth_account_table: Optional[Type[SQLAlchemyBaseOAuthAccountTable]]
+    oauth_account_table: Optional[Type[OAP]]
 
     def __init__(
         self,
         session: AsyncSession,
         user_table: Type[UP],
-        oauth_account_table: Optional[Type[SQLAlchemyBaseOAuthAccountTable]] = None,
+        oauth_account_table: Optional[Type[OAP]] = None,
     ):
         self.session = session
         self.user_table = user_table


### PR DESCRIPTION
let’s not hardcode OAuthAccount type and use the protocol instead.
