### PR TITLE
fix: add mapped types in TYPE_CHECKING block for all cols

### DIFF
--- a/fastapi_users_db_sqlalchemy/__init__.py
+++ b/fastapi_users_db_sqlalchemy/__init__.py
@@ -22,12 +22,12 @@ class SQLAlchemyBaseUserTable(Generic[ID]):
     __tablename__ = "user"
 
     if TYPE_CHECKING:  # pragma: no cover
-        id: ID
-        email: str
-        hashed_password: str
-        is_active: bool
-        is_superuser: bool
-        is_verified: bool
+        id: ID | Mapped[Mapped]
+        email: str | Mapped[str]
+        hashed_password: str | Mapped[str]
+        is_active: bool | Mapped[bool]
+        is_superuser: bool | Mapped[bool]
+        is_verified: bool | Mapped[bool]
     else:
         email: Mapped[str] = mapped_column(
             String(length=320), unique=True, index=True, nullable=False


### PR DESCRIPTION
Hi @frankie567  👋🏻 

I've been playing with fastapi-users and I have to remove unique constaint on email col due to soft deletes. Hence, I added my own email col however as I've email col like this:
```py
    email: Mapped[str] = mapped_column(
        String(length=320),
        index=True,
        nullable=False,
        kw_only=True,
    )
```

'm getting error from pylance `Override type "Mapped[str]" is not the same as base type:
![image](https://github.com/user-attachments/assets/4da8900e-0d29-4982-9dda-9e024301ddcc)


Hence, I added unique of `Mapped` as well.

However, I can't understand why we need seperate `if TYPE_CHECKING:`? If we directly write cols like normal table it should work. If removing `if TYPE_CHECKING:` we can reject this PR as problem should solve automatically as now type will be same.

Big Thanks for this lib ❤️ 