### PR TITLE
Bug-Fix: when using Postgresql the user and oauth_account objects get disconnected from the session. Reconnect them with a refresh()

### DIFF
--- a/fastapi_users_db_sqlalchemy/__init__.py
+++ b/fastapi_users_db_sqlalchemy/__init__.py
@@ -169,6 +169,8 @@ class SQLAlchemyUserDatabase(Generic[UP, ID], BaseUserDatabase[UP, ID]):
         self.session.add(user)
 
         await self.session.commit()
+        await self.session.refresh(oauth_account)
+        await self.session.refresh(user)
 
         return user
 
@@ -182,6 +184,8 @@ class SQLAlchemyUserDatabase(Generic[UP, ID], BaseUserDatabase[UP, ID]):
             setattr(oauth_account, key, value)
         self.session.add(oauth_account)
         await self.session.commit()
+        await self.session.refresh(oauth_account)
+        await self.session.refresh(user)
 
         return user
 


### PR DESCRIPTION
Happens only when using Postgresql, with Sqlite there are no problems. Problem exists probably also in other implementations (e.g. sqlmodel)