### PR TITLE
Increase max access and refresh token length to 4096

### DIFF
--- a/fastapi_users_db_sqlalchemy/__init__.py
+++ b/fastapi_users_db_sqlalchemy/__init__.py
@@ -69,10 +69,10 @@ class SQLAlchemyBaseOAuthAccountTable(Generic[ID]):
         oauth_name: Mapped[str] = mapped_column(
             String(length=100), index=True, nullable=False
         )
-        access_token: Mapped[str] = mapped_column(String(length=1024), nullable=False)
+        access_token: Mapped[str] = mapped_column(String(length=4096), nullable=False)
         expires_at: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
         refresh_token: Mapped[Optional[str]] = mapped_column(
-            String(length=1024), nullable=True
+            String(length=4096), nullable=True
         )
         account_id: Mapped[str] = mapped_column(
             String(length=320), index=True, nullable=False


### PR DESCRIPTION
This PR updates the `SQLAlchemyBaseOAuthAccountTable` class to increase the maximum length of the access and refresh token fields from 1024 to 4096 chars.
This is necessary because, OAuth2 providers like Authentik generate tokens with an algorithm like RS256. These the access tokens exceed the max length of 1024 chars which leads to errors like these, ultimately blocking the user from logging in.

```
sqlalchemy.exc.DataError: (psycopg.errors.StringDataRightTruncation) value too long for type character varying(1024)
```

Related issues: 
- https://github.com/fastapi-users/fastapi-users/issues/1523
- https://github.com/fastapi-users/fastapi-users-db-sqlalchemy/issues/20