### PR TITLE
Handle UUID formatting for SQLite dialect

### DIFF
--- a/fastapi_users_db_sqlalchemy/generics.py
+++ b/fastapi_users_db_sqlalchemy/generics.py
@@ -32,6 +32,8 @@ class GUID(TypeDecorator):  # pragma: no cover
             return value
         elif dialect.name == "postgresql":
             return str(value)
+        elif dialect.name == "sqlite":
+            return str(value).replace("-", "")
         else:
             if not isinstance(value, uuid.UUID):
                 return str(uuid.UUID(value))


### PR DESCRIPTION
This change allows fastapi-users to use UUIDs sqlite for the sqlalchemy user model.

Changes made:
- added special case to GUID generic for sqlite dialect

Tests performed:
- ran the changes locally