### PR TITLE
Remove upper version bound on SQLAlchemy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "fastapi-users >= 10.0.0",
-    "sqlalchemy[asyncio] >=2.0.0,<2.1.0",
+    "sqlalchemy[asyncio] >=2.0.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
If #25 sounds reasonable this is a simple update to the pyproject.toml

I've manually installed the beta (2.1.0.b2) and ran the tests to verify nothing directly breaks.

